### PR TITLE
[SEC-1131] Extend SHA256.swift by functionality to calculate SHA256 checksum using a buffer

### DIFF
--- a/Example/Krypt.xcodeproj/project.pbxproj
+++ b/Example/Krypt.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		EBE7E19022848ACE003029C8 /* kvconnect-root-ca-pem in Resources */ = {isa = PBXBuildFile; fileRef = EBE7E18D22848A00003029C8 /* kvconnect-root-ca-pem */; };
 		EBE7E19122848ACE003029C8 /* kvconnect-user-ca-pem in Resources */ = {isa = PBXBuildFile; fileRef = EBE7E18E22848A98003029C8 /* kvconnect-user-ca-pem */; };
 		EBE7E19222848ACE003029C8 /* kvconnect-user-ca-pem-expired in Resources */ = {isa = PBXBuildFile; fileRef = EBE7E18F22848AC2003029C8 /* kvconnect-user-ca-pem-expired */; };
+		F89BB73D23D6F4A300D1163A /* SHA256Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F89BB73C23D6F4A300D1163A /* SHA256Tests.swift */; };
 		F8FE7631CB357489E6F46CAE /* Pods_Krypt_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B5353F61A433C768E5238155 /* Pods_Krypt_Example.framework */; };
 /* End PBXBuildFile section */
 
@@ -139,6 +140,7 @@
 		EBE7E18E22848A98003029C8 /* kvconnect-user-ca-pem */ = {isa = PBXFileReference; lastKnownFileType = text; path = "kvconnect-user-ca-pem"; sourceTree = "<group>"; };
 		EBE7E18F22848AC2003029C8 /* kvconnect-user-ca-pem-expired */ = {isa = PBXFileReference; lastKnownFileType = text; path = "kvconnect-user-ca-pem-expired"; sourceTree = "<group>"; };
 		EE79515EE4A9941AF4F05C9D /* Pods_Krypt_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Krypt_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		F89BB73C23D6F4A300D1163A /* SHA256Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SHA256Tests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -225,6 +227,7 @@
 				EB007E142276EA61001BD473 /* KVConnectDecryptionTests.swift */,
 				AD9EBA832283279900DB8E73 /* PEMConverterTests.swift */,
 				AD1568BE21F8D494008572DA /* RSATests.swift */,
+				F89BB73C23D6F4A300D1163A /* SHA256Tests.swift */,
 				AD13AB55225F7AAB00E65BBD /* SMIMETests.swift */,
 				5021071722C1366B008EFF62 /* PKCS8Tests.swift */,
 				AD6DBE3E237E088E003567FA /* X509Tests.swift */,
@@ -575,6 +578,7 @@
 				AD6B2D492231111D00C03EC1 /* CSRTests.swift in Sources */,
 				AD4513DB21FB3E8D0053C76B /* EHREncryptionTests.swift in Sources */,
 				AD1568C821F9E0CB008572DA /* KeyTests.swift in Sources */,
+				F89BB73D23D6F4A300D1163A /* SHA256Tests.swift in Sources */,
 				AD6DBE3F237E088E003567FA /* X509Tests.swift in Sources */,
 				AD9EBA842283279900DB8E73 /* PEMConverterTests.swift in Sources */,
 				EB007E162276EA8F001BD473 /* KVConnectDecryptionTests.swift in Sources */,

--- a/Example/Krypt.xcodeproj/project.pbxproj
+++ b/Example/Krypt.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		EBE7E19122848ACE003029C8 /* kvconnect-user-ca-pem in Resources */ = {isa = PBXBuildFile; fileRef = EBE7E18E22848A98003029C8 /* kvconnect-user-ca-pem */; };
 		EBE7E19222848ACE003029C8 /* kvconnect-user-ca-pem-expired in Resources */ = {isa = PBXBuildFile; fileRef = EBE7E18F22848AC2003029C8 /* kvconnect-user-ca-pem-expired */; };
 		F89BB73D23D6F4A300D1163A /* SHA256Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F89BB73C23D6F4A300D1163A /* SHA256Tests.swift */; };
+		F8FA64EC23DAEAFD005010DB /* largeTestFile in Resources */ = {isa = PBXBuildFile; fileRef = F8FA64EB23DAEAFD005010DB /* largeTestFile */; };
 		F8FE7631CB357489E6F46CAE /* Pods_Krypt_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B5353F61A433C768E5238155 /* Pods_Krypt_Example.framework */; };
 /* End PBXBuildFile section */
 
@@ -141,6 +142,7 @@
 		EBE7E18F22848AC2003029C8 /* kvconnect-user-ca-pem-expired */ = {isa = PBXFileReference; lastKnownFileType = text; path = "kvconnect-user-ca-pem-expired"; sourceTree = "<group>"; };
 		EE79515EE4A9941AF4F05C9D /* Pods_Krypt_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Krypt_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F89BB73C23D6F4A300D1163A /* SHA256Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SHA256Tests.swift; sourceTree = "<group>"; };
+		F8FA64EB23DAEAFD005010DB /* largeTestFile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = largeTestFile; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -322,6 +324,7 @@
 		ADC231F62204478800A57D6A /* Files */ = {
 			isa = PBXGroup;
 			children = (
+				F8FA64EA23DAEAD7005010DB /* SHA256 */,
 				AD13AB4B225F778800E65BBD /* E2EE */,
 				AD13AB4C225F779500E65BBD /* OpenSSL */,
 				AD13AB4D225F77C500E65BBD /* CSR */,
@@ -347,6 +350,14 @@
 				EB007E2B22772C0F001BD473 /* Data+String.swift */,
 			);
 			path = Extensions;
+			sourceTree = "<group>";
+		};
+		F8FA64EA23DAEAD7005010DB /* SHA256 */ = {
+			isa = PBXGroup;
+			children = (
+				F8FA64EB23DAEAFD005010DB /* largeTestFile */,
+			);
+			path = SHA256;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -481,6 +492,7 @@
 				EB0A5E592268750C000FD79C /* wrong-privatekey-open-pem in Resources */,
 				EBE7E19222848ACE003029C8 /* kvconnect-user-ca-pem-expired in Resources */,
 				EB3DD09E22647F23007A7C1E /* openssl-private-key-pkcs1-2048-pem in Resources */,
+				F8FA64EC23DAEAFD005010DB /* largeTestFile in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Example/Tests/SHA256Tests.swift
+++ b/Example/Tests/SHA256Tests.swift
@@ -13,7 +13,7 @@ class SHA256Tests: XCTestCase {
   // Computed using `openssl dgst -sha256 -hex [file path]
   private let expectedHash = "4b9ecf8a918594442fa56d14f2f8e975b258d134bf71c3a05c913b952d40af46"
 
-  func testSAH256Calculation_nonBuffered__shouldProduceCorrectHash() {
+  func testDigestData__shouldProduceExpectedHash() {
     // given
     let testData = TestData.largeTestData
     // when

--- a/Example/Tests/SHA256Tests.swift
+++ b/Example/Tests/SHA256Tests.swift
@@ -22,7 +22,7 @@ class SHA256Tests: XCTestCase {
     XCTAssertEqual(digest, Data(hex: expectedHash))
   }
 
-  func testSHA256Calculation_buffered__shouldProduceCorrectHash() {
+  func testDigestFile_whenDataLargeEnoughFor5BufferFills__shouldProduceExpectedHash() {
     // given
     /// Test data large enough to force at least 5 buffer fills
     let testData = TestData.largeTestData

--- a/Example/Tests/SHA256Tests.swift
+++ b/Example/Tests/SHA256Tests.swift
@@ -10,12 +10,24 @@ import Krypt
 import XCTest
 
 class SHA256Tests: XCTestCase {
+  func testSAH256Calculation_nonBuffered__shouldProduceCorrectHash() {
+    // given
+    let testData = TestData.largeTestData
+    /// Was calculated locally using openssl
+    let expectedHash = "4b9ecf8a918594442fa56d14f2f8e975b258d134bf71c3a05c913b952d40af46"
+    // when
+    let digest = SHA256.digest(testData.data)
+    // then
+    XCTAssertEqual(digest, Data(hex: expectedHash))
+  }
+
   func testSHA256Calculation_buffered__shouldProduceSameAsUnbuffered() {
     // given
-    let testData = TestData.kvConnectEmailVerificationInvalidSignatureDigest
+    /// Test data large enough to force at least 5 buffer fills
+    let testData = TestData.largeTestData
     // when
     let unbufferedDigest = SHA256.digest(testData.data)
-    let bufferedDigest = SHA256.digest(from: testData.url)
+    let bufferedDigest = try! SHA256.digest(file: testData.url)
     // then
     XCTAssertEqual(unbufferedDigest, bufferedDigest)
   }

--- a/Example/Tests/SHA256Tests.swift
+++ b/Example/Tests/SHA256Tests.swift
@@ -10,25 +10,35 @@ import Krypt
 import XCTest
 
 class SHA256Tests: XCTestCase {
+  // Computed using `openssl dgst -sha256 -hex [file path]
+  private let expectedHash = "4b9ecf8a918594442fa56d14f2f8e975b258d134bf71c3a05c913b952d40af46"
+
   func testSAH256Calculation_nonBuffered__shouldProduceCorrectHash() {
     // given
     let testData = TestData.largeTestData
-    /// Was calculated locally using openssl
-    let expectedHash = "4b9ecf8a918594442fa56d14f2f8e975b258d134bf71c3a05c913b952d40af46"
     // when
     let digest = SHA256.digest(testData.data)
     // then
     XCTAssertEqual(digest, Data(hex: expectedHash))
   }
 
-  func testSHA256Calculation_buffered__shouldProduceSameAsUnbuffered() {
+  func testSHA256Calculation_buffered__shouldProduceCorrectHash() {
     // given
     /// Test data large enough to force at least 5 buffer fills
     let testData = TestData.largeTestData
     // when
-    let unbufferedDigest = SHA256.digest(testData.data)
     let bufferedDigest = try! SHA256.digest(file: testData.url)
     // then
-    XCTAssertEqual(unbufferedDigest, bufferedDigest)
+    XCTAssertEqual(bufferedDigest, Data(hex: expectedHash))
+  }
+
+  func testSHA256Calculation_bufferedWithCustomBufferSize__shouldProduceCorrectHash() {
+    // given
+    /// Test data large enough to force at least 5 buffer fills
+    let testData = TestData.largeTestData
+    // when
+    let bufferedDigest = try! SHA256.digest(file: testData.url, withBufferSize: 1024)
+    // then
+    XCTAssertEqual(bufferedDigest, Data(hex: expectedHash))
   }
 }

--- a/Example/Tests/SHA256Tests.swift
+++ b/Example/Tests/SHA256Tests.swift
@@ -32,7 +32,7 @@ class SHA256Tests: XCTestCase {
     XCTAssertEqual(bufferedDigest, Data(hex: expectedHash))
   }
 
-  func testSHA256Calculation_bufferedWithCustomBufferSize__shouldProduceCorrectHash() {
+  func testDigestFile_withCustomBufferSize__shouldProduceExpectedHash() {
     // given
     /// Test data large enough to force at least 5 buffer fills
     let testData = TestData.largeTestData

--- a/Example/Tests/SHA256Tests.swift
+++ b/Example/Tests/SHA256Tests.swift
@@ -1,0 +1,22 @@
+//
+//  SHA256Tests.swift
+//  Krypt_Tests
+//
+//  Created by Simon Feistel on 21.01.20.
+//  Copyright © 2020 CocoaPods. All rights reserved.
+//
+
+import Krypt
+import XCTest
+
+class SHA256Tests: XCTestCase {
+  func testSHA256Calculation_buffered__shouldProduceSameAsUnbuffered() {
+    // given
+    let testData = TestData.kvConnectEmailVerificationInvalidSignatureDigest
+    // when
+    let unbufferedDigest = SHA256.digest(testData.data)
+    let bufferedDigest = SHA256.digest(from: testData.url)
+    // then
+    XCTAssertEqual(unbufferedDigest, bufferedDigest)
+  }
+}

--- a/Example/Tests/TestData.swift
+++ b/Example/Tests/TestData.swift
@@ -44,6 +44,7 @@ enum TestData: String {
   case kvConnectRootCAPEM = "kvconnect-root-ca-pem"
   case kvConnectUserCAPEM = "kvconnect-user-ca-pem"
   case kvConnectUserCAPEMExpired = "kvconnect-user-ca-pem-expired"
+  case largeTestData = "largeTestFile"
 
   var data: Data {
     guard let data = try? Data(contentsOf: self.url)

--- a/Example/Tests/TestData.swift
+++ b/Example/Tests/TestData.swift
@@ -46,14 +46,19 @@ enum TestData: String {
   case kvConnectUserCAPEMExpired = "kvconnect-user-ca-pem-expired"
 
   var data: Data {
-    guard
-      let url = Bundle(for: TestDataClass.self)
-      .url(forResource: self.rawValue, withExtension: nil),
-      let data = try? Data(contentsOf: url)
+    guard let data = try? Data(contentsOf: self.url)
     else {
       fatalError("No file found")
     }
     return data
+  }
+
+  var url: URL {
+    guard let url = Bundle(for: TestDataClass.self)
+      .url(forResource: self.rawValue, withExtension: nil) else {
+      fatalError("URL not found")
+    }
+    return url
   }
 
   var base64Decoded: Data {

--- a/Krypt/Source/SHA256.swift
+++ b/Krypt/Source/SHA256.swift
@@ -20,4 +20,41 @@ public struct SHA256 {
     }
     return status == errSecSuccess ? Data(hash) : nil
   }
+
+  // MARK: - Buffered SHA-256 Calculation
+
+  public static func digest(from file: URL, with bufferSize: Int = 1024 * 1024) -> Data? {
+    guard let handle = try? FileHandle(forReadingFrom: file) else { return nil }
+    /// Close file handle on scope exit
+    defer {
+      handle.closeFile()
+    }
+    /// Common Crypto SHA256 Setup
+    var context = CC_SHA256_CTX()
+    CC_SHA256_Init(&context)
+
+    /// Fill buffer in an autoreleasepool so we dont run out of memory for large files
+    while autoreleasepool(invoking: {
+      /// Fill buffer
+      let data = handle.readData(ofLength: bufferSize)
+      /// Update SHA256
+      if data.count > 0 {
+        data.withUnsafeBytes {
+          _ = CC_SHA256_Update(&context, $0.baseAddress, numericCast(data.count))
+        }
+        return true
+      } else {
+        /// EOF
+        return false
+      }
+    }) {}
+
+    /// SHA256 Digest & Finalize
+    var digest = Data(count: Int(CC_SHA256_DIGEST_LENGTH))
+    digest.withUnsafeMutableBytes {
+      _ = CC_SHA256_Final($0.bindMemory(to: UInt8.self).baseAddress, &context)
+    }
+
+    return digest
+  }
 }

--- a/Krypt/Source/SHA256.swift
+++ b/Krypt/Source/SHA256.swift
@@ -26,8 +26,8 @@ public struct SHA256 {
   /// Calculates SHA256 hash of a given file using a buffer to avoid running out of memory for potentially large files
   /// - Parameters:
   ///   - url: The url to the file to calculate the SHA256 hash for
-  ///   - bufferSize: The size of the buffer to use in bytes, defaults to 1024 * 1024 bytes =  1MB
-  public static func digest(file url: URL, with bufferSize: Int = 1024 * 1024) throws -> Data {
+  ///   - withBufferSize: The size of the buffer to use in bytes, defaults to 1024 * 1024 bytes =  1MB
+  public static func digest(file url: URL, withBufferSize: Int = 1024 * 1024) throws -> Data {
     let handle = try FileHandle(forReadingFrom: url)
     /// Close file handle on scope exit
     defer {
@@ -40,7 +40,7 @@ public struct SHA256 {
     /// Fill buffer in an autoreleasepool so we dont run out of memory for large files
     while autoreleasepool(invoking: {
       /// Fill buffer
-      let data = handle.readData(ofLength: bufferSize)
+      let data = handle.readData(ofLength: withBufferSize)
       /// Update SHA256
       if data.count > 0 {
         data.withUnsafeBytes {

--- a/Krypt/Source/SHA256.swift
+++ b/Krypt/Source/SHA256.swift
@@ -23,8 +23,12 @@ public struct SHA256 {
 
   // MARK: - Buffered SHA-256 Calculation
 
-  public static func digest(from file: URL, with bufferSize: Int = 1024 * 1024) -> Data? {
-    guard let handle = try? FileHandle(forReadingFrom: file) else { return nil }
+  /// Calculates SHA256 hash of a given file using a buffer to avoid running out of memory for potentially large files
+  /// - Parameters:
+  ///   - url: The url to the file to calculate the SHA256 hash for
+  ///   - bufferSize: The size of the buffer to use in bytes, defaults to 1024 * 1024 bytes =  1MB
+  public static func digest(file url: URL, with bufferSize: Int = 1024 * 1024) throws -> Data {
+    let handle = try FileHandle(forReadingFrom: url)
     /// Close file handle on scope exit
     defer {
       handle.closeFile()


### PR DESCRIPTION
… which is crucial for large files not to cause the app to run out of memory

- Add UnitTest ensuring this produces the same result as the existing SHA256 hashing via data
- Adjust TestData.swift by convenience url property in the process